### PR TITLE
help: Fix URL escaping of third example

### DIFF
--- a/data/templates/help.html
+++ b/data/templates/help.html
@@ -26,7 +26,7 @@
     <ul class="square">
       <li><a href="{{ urlFor('search') }}?q=Tim%20TimStarling"><kbd>Tim TimStarling</kbd></a>: quips containing "Tim" or "TimStarling"</li>
       <li><a href="{{ urlFor('search') }}?q=%22browser%20cache%22"><kbd>"browser cache"</kbd></a>: quips containing the phrase "browser cache"</li>
-      <li><a href="{{ urlFor('search') }}?q=bd808%20%2B-(reedy|ori)"><kbd>bd808 +-(reedy|ori)</kbd></a>: quips containing "bd808" and not "reedy" or "ori"</li>
+      <li><a href="{{ urlFor('search') }}?q=bd808+%2B-%28reedy%7Cori%29"><kbd>bd808 +-(reedy|ori)</kbd></a>: quips containing "bd808" and not "reedy" or "ori"</li>
       <li><a href="{{ urlFor('search') }}?q=%2Bdomas%20%2Breedy"><kbd>+domas +reedy</kbd></a>: quips containing "domas" and "reedy"</li>
     </ul>
   </section>


### PR DESCRIPTION
The previous URL didn’t work for me, resulting in a 404 page; the new URL is the result of typing the query into the search input and then looking at document.location in the console. (The URL that Firefox shows in the address bar doesn’t work when pasted into a new tab, since Firefox partially decodes it in a way that Slim doesn’t seem to like.)

Tested in Firefox, Chromium, and GNOME Web (<abbr title="formerly known as">fka</abbr> Epiphany), which ought to cover the three major surviving browser engignes.